### PR TITLE
View order button is only visible when logged in

### DIFF
--- a/cypress/integration/visitorCanRegisterForAnAccount.feature.js
+++ b/cypress/integration/visitorCanRegisterForAnAccount.feature.js
@@ -26,6 +26,7 @@ describe("A button to add product to order", () => {
         "Successfull registration"
       );
       cy.get('[data-cy="order-button-1"]').should("be.visible");
+      cy.get('[data-cy="view-order-button"]').should("be.visible");
     });
   });
 });

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -53,11 +53,13 @@ class App extends Component {
             name="Beverages"
             onClick={() => this.setState({ tab: "beverages" })}
           />
-          <Menu.Item
+          {this.state.authenticated && (
+            <Menu.Item
             data-cy="view-order-button"
             name="View Order"
             onClick={() => this.setState({ tab: "Your order" })}
           />
+          )}
         </Menu>
         <LogIn authStatus={this.setAuthStatus} />
         {(this.state.tab === "Your order")


### PR DESCRIPTION
### PT: https://www.pivotaltracker.com/story/show/177995340

### User strory
As a dev team
to have consistency in design
All ordered related elements should be visible only to logged in customers

### Sugested changes
- Make button visible after logged in
- Updated UserCanRegistrateForAnAccount test to test if button is visible
![Screenshot 2021-05-02 at 20 07 08](https://user-images.githubusercontent.com/60035332/116823002-3a786900-ab82-11eb-950e-bd23aebc356c.png)
![Screenshot 2021-05-02 at 20 06 48](https://user-images.githubusercontent.com/60035332/116823005-3d735980-ab82-11eb-8e59-1acb00e80cbe.png)

